### PR TITLE
Support of reference manager to purge ephemeral outputs

### DIFF
--- a/alexflow/adapters/executor/_reference_manager.py
+++ b/alexflow/adapters/executor/_reference_manager.py
@@ -1,7 +1,7 @@
-from typing import Dict, Set
-from collections import defaultdict
+from typing import Dict, Set, List
+from collections import defaultdict, OrderedDict
 
-from alexflow.core import AbstractTask, Storage
+from alexflow.core import AbstractTask, Storage, Output
 from alexflow.helper import flatten
 
 from logging import getLogger
@@ -20,14 +20,14 @@ class ReferenceManager:
 
     def add(self, task: AbstractTask) -> None:
         """Add new task to reference manager in case you have additional task with DynamicTask"""
-        inputs = flatten(task.output())
+        inputs = _uniq(flatten(task.output()))
 
         for inp in inputs:
 
             self._refcount[inp.key].add(task.task_id)
 
     def remove(self, task: AbstractTask):
-        inputs = flatten(task.input())
+        inputs = _uniq(flatten(task.input()))
 
         for inp in inputs:
 
@@ -41,6 +41,11 @@ class ReferenceManager:
                 logger.debug(f"Purging Output(key={inp.key})")
 
                 inp.assign_storage(self._storage).remove()
+
+
+def _uniq(items: List[Output]):
+    o = OrderedDict([(item.key, item) for item in items])
+    return list(o.values())
 
 
 def _to_ref_map(tasks: Dict[str, AbstractTask]) -> Dict[str, Set[str]]:

--- a/alexflow/adapters/executor/_reference_manager.py
+++ b/alexflow/adapters/executor/_reference_manager.py
@@ -4,6 +4,11 @@ from collections import defaultdict
 from alexflow.core import AbstractTask, Storage
 from alexflow.helper import flatten
 
+from logging import getLogger
+
+
+logger = getLogger(__name__)
+
 
 class ReferenceManager:
     """Manages reference count of Output object and purge once all referenced tasks are resolved.
@@ -32,6 +37,8 @@ class ReferenceManager:
                 continue
 
             if inp.ephemeral:
+
+                logger.debug(f"Purging Output(key={inp.key})")
 
                 inp.assign_storage(self._storage).remove()
 

--- a/alexflow/adapters/executor/_reference_manager.py
+++ b/alexflow/adapters/executor/_reference_manager.py
@@ -33,10 +33,12 @@ class ReferenceManager:
     def remove(self, task: AbstractTask):
         inputs = _uniq(flatten(task.input()))
 
+        # Reduce reference count first to cover the case:
+        #     One input depends on the other in a same list
         for inp in inputs:
-
             self._refcount[inp.key].remove(task.task_id)
 
+        for inp in inputs:
             _recursive_purge_if_ephemeral(
                 inp,
                 storage=self._storage,

--- a/alexflow/adapters/executor/_reference_manager.py
+++ b/alexflow/adapters/executor/_reference_manager.py
@@ -1,0 +1,64 @@
+from typing import Dict, Set
+from collections import defaultdict
+
+from alexflow.core import AbstractTask, Storage
+from alexflow.helper import flatten
+
+
+class ReferenceManager:
+    """Manages reference count of Output object and purge found none referenced output
+    """
+
+    def __init__(self, tasks: Dict[str, AbstractTask], storage: Storage):
+        self._refcount: Dict[str, Set[str]] = _to_ref_map(tasks)
+        self._storage: Storage = storage
+
+    def add(self, task: AbstractTask) -> None:
+        inputs = flatten(task.output())
+
+        for inp in inputs:
+
+            self._refcount[inp.output_id].add(task.task_id)
+
+    def remove(self, task: AbstractTask):
+
+        inputs = flatten(task.input())
+
+        for inp in inputs:
+
+            self._refcount[inp.output_id].remove(task.task_id)
+
+            if len(self._refcount[inp.output_id]) > 0:
+                continue
+
+            if inp.ephemeral:
+
+                inp.assign_storage(self._storage).remove()
+
+
+def _to_ref_map(tasks: Dict[str, AbstractTask]) -> Dict[str, Set[str]]:
+    """Get reference count dictionary
+    """
+
+    # key = output_id, value set of task_ids who uses the output
+    ref: Dict[str, Set[str]] = defaultdict(set)
+
+    while len(tasks) > 0:
+
+        next_tasks: Dict[str, AbstractTask] = {}
+
+        for task_id, task in tasks.items():
+
+            inputs = flatten(task.input())
+
+            for inp in inputs:
+                ref[inp.output_id].add(task_id)
+
+            dependent_tasks = {inp.src_task.task_id: inp.src_task for inp in inputs}
+
+            for dependent_task_id, task in dependent_tasks.items():
+                next_tasks[dependent_task_id] = task
+
+        tasks = next_tasks
+
+    return ref

--- a/alexflow/adapters/executor/_reference_manager.py
+++ b/alexflow/adapters/executor/_reference_manager.py
@@ -6,7 +6,7 @@ from alexflow.helper import flatten
 
 
 class ReferenceManager:
-    """Manages reference count of Output object and purge found none referenced output
+    """Manages reference count of Output object and purge once all referenced tasks are resolved.
     """
 
     def __init__(self, tasks: Dict[str, AbstractTask], storage: Storage):
@@ -14,6 +14,7 @@ class ReferenceManager:
         self._storage: Storage = storage
 
     def add(self, task: AbstractTask) -> None:
+        """Add new task to reference manager in case you have additional task with DynamicTask"""
         inputs = flatten(task.output())
 
         for inp in inputs:
@@ -21,7 +22,6 @@ class ReferenceManager:
             self._refcount[inp.output_id].add(task.task_id)
 
     def remove(self, task: AbstractTask):
-
         inputs = flatten(task.input())
 
         for inp in inputs:

--- a/alexflow/adapters/executor/_reference_manager.py
+++ b/alexflow/adapters/executor/_reference_manager.py
@@ -24,16 +24,16 @@ class ReferenceManager:
 
         for inp in inputs:
 
-            self._refcount[inp.output_id].add(task.task_id)
+            self._refcount[inp.key].add(task.task_id)
 
     def remove(self, task: AbstractTask):
         inputs = flatten(task.input())
 
         for inp in inputs:
 
-            self._refcount[inp.output_id].remove(task.task_id)
+            self._refcount[inp.key].remove(task.task_id)
 
-            if len(self._refcount[inp.output_id]) > 0:
+            if len(self._refcount[inp.key]) > 0:
                 continue
 
             if inp.ephemeral:
@@ -47,7 +47,7 @@ def _to_ref_map(tasks: Dict[str, AbstractTask]) -> Dict[str, Set[str]]:
     """Get reference count dictionary
     """
 
-    # key = output_id, value set of task_ids who uses the output
+    # key = Output.key, value set of task_ids who uses the output
     ref: Dict[str, Set[str]] = defaultdict(set)
 
     while len(tasks) > 0:
@@ -59,7 +59,7 @@ def _to_ref_map(tasks: Dict[str, AbstractTask]) -> Dict[str, Set[str]]:
             inputs = flatten(task.input())
 
             for inp in inputs:
-                ref[inp.output_id].add(task_id)
+                ref[inp.key].add(task_id)
 
             dependent_tasks = {inp.src_task.task_id: inp.src_task for inp in inputs}
 

--- a/alexflow/adapters/executor/alexflow.py
+++ b/alexflow/adapters/executor/alexflow.py
@@ -95,7 +95,7 @@ class ResourceManager:
 
 
 def _execute(workflow: Workflow, workers: int, resources: Dict[str, int]):  # noqa
-    buffer = 100
+    buffer = 10
 
     manager = Manager()
 
@@ -167,13 +167,17 @@ def _execute(workflow: Workflow, workers: int, resources: Dict[str, int]):  # no
                     time.sleep(0.2)
                     continue
 
-                next_tasks = {}
+                next_tasks = OrderedDict()
 
                 for task in tasks.values():
                     if task.task_id in running:
                         continue
 
                     if is_completed(task, workflow.storage):
+                        continue
+
+                    if q_set.q_in.qsize() >= buffer:
+                        next_tasks[task.task_id] = task
                         continue
 
                     inputs = flatten(task.input())

--- a/alexflow/core.py
+++ b/alexflow/core.py
@@ -105,6 +105,8 @@ class NotFound(StorageError):
 @dataclass(frozen=True)
 class Output(Serializable):
     """
+    Attrs:
+        ephemeral: Boolean flag whether the Output object can be removed once all the referenced tasks are completed.
     """
 
     src_task: "AbstractTask"
@@ -112,6 +114,7 @@ class Output(Serializable):
     storage: Optional[Storage] = field(
         default=None, compare=False, repr=False,
     )
+    ephemeral: bool = field(default=False, compare=False, repr=False)
 
     @cached_property
     def output_id(self) -> str:
@@ -134,6 +137,9 @@ class Output(Serializable):
 
     def load(self):
         raise NotImplementedError
+
+    def as_ephemeral(self) -> "Output":
+        return replace(self, ephemeral=True)
 
 
 @dataclass(frozen=True)

--- a/tests/test_adapters/test_executor/test_reference_manager.py
+++ b/tests/test_adapters/test_executor/test_reference_manager.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock
+
+from alexflow.adapters.executor._reference_manager import ReferenceManager
+from alexflow.testing.tasks import Task1, Task2
+
+
+def test_if_reference_manager_can_handle_mixed_ephemeral_condition():
+    """
+    For the case 1 output is represented as both ephemeral and none-ephemeral, the output
+    object is finally none-ephemeral and should not be deleted.
+    """
+    storage = MagicMock()
+
+    base = Task1()
+
+    variant1 = Task2(parent=base.output(), name="variant1")
+    variant2 = Task2(parent=base.output().as_ephemeral(), name="variant2")
+
+    tasks = [variant1, variant2]
+
+    manager = ReferenceManager({task.task_id: task for task in tasks}, storage)
+
+    assert manager._ephemeral_map[base.output().key] is False
+
+    manager.remove(base)
+    manager.remove(variant1)
+    manager.remove(variant2)
+
+    storage.remove.assert_not_called()


### PR DESCRIPTION
## Motivation

For the case your task have intermediate results only used while execution of the task, for some case we want to remove those intermediate results once all depending tasks are completed. This will reduces the maximum storage usage in a single workflow execution and make it possible to execute the task who have very large intermediate results with limited disk sizes.

## Design

- Base output class will have new attribute named `ephemeral`, which represents whether the output can be purged once resolved.
- Executor will check output object's reference count and purge once all references are gone if Output is ephemeral.
- Considers Output to be ephemeral only when all the referenced task treat it as ephemeral. So if there is any task which does not treat it as none-ephemeral, then it won't be purged even all the dependent tasks are resolved.

## Limitation
- At this moment, only supported by alexflow executor.
- In case you have DynamicTask and produces the task dynamically, you cannot gain the benefit and might requires the re-execution of the task.
